### PR TITLE
Sprint 2: API-Colleges-autofillCollege

### DIFF
--- a/backend/controller/college.controller.js
+++ b/backend/controller/college.controller.js
@@ -1,9 +1,6 @@
 require("dotenv").config();
 const db = require("../db");
 
-// Technically should be in a env or smth but who cares ++ this is a get only endpoint
-const SCORECARD_API_KEY="BPGdOVwiRg9I45TLDD1bQfIxQjZW24K49ZEraSbS";
-
 class collegeController {
 
     async allColleges() {
@@ -164,13 +161,23 @@ class collegeController {
     // deleteAssignment
 
     // fetchFromScorecard
-    async fetchFromScorecard(namePrefix, desiredFields){
-        // DOCUMENTATION: https://github.com/RTICWDT/open-data-maker/blob/master/API.md
+    /**
+     * Fetch school data from collegescorecard api
+     * @param {string} namePrefix - name to search by
+     * @param {string[]} desiredFields - limit desired fields, defaults to all fields
+     * @param {bool} findExact - return names with exact matches only, defaults to false
+     * @returns {object} If findExact, an object of the school info is returned. If not, a paged object of all autocomplete matches 
+     */
+    async fetchFromScorecard(namePrefix, desiredFields=[], findExact=false, page=0, perPage=20){
         
+        // DOCUMENTATION: https://github.com/RTICWDT/open-data-maker/blob/master/API.md
+        // Technically should be in a env or smth but who cares ++ this is a get only endpoint  
+        const SCORECARD_API_KEY="BPGdOVwiRg9I45TLDD1bQfIxQjZW24K49ZEraSbS";
+
         // reformat spaces for url
         const formattedPrefix=namePrefix.replace(/ /g, '%20');
 
-        let baseURL="https://api.data.gov/ed/collegescorecard/v1/schools.json?api_key="+SCORECARD_API_KEY;
+        let baseURL="https://api.data.gov/ed/collegescorecard/v1/schools.json?api_key="+SCORECARD_API_KEY+"&page="+page+"&per_page="+perPage;
 
         if(formattedPrefix.length!=0){
             baseURL+="&school.name="+formattedPrefix;
@@ -182,7 +189,15 @@ class collegeController {
 
         const response = await fetch(baseURL);
         const data = await response.json();
-
+        console.log(baseURL);
+        if(findExact){
+            for (const result of data.results) {
+                if (result["school.name"] === namePrefix) {
+                    return result;
+                }
+            }
+            return {};
+        }
         return data;
     }
 }

--- a/backend/controller/college.controller.js
+++ b/backend/controller/college.controller.js
@@ -1,6 +1,8 @@
 require("dotenv").config();
 const db = require("../db");
 
+// Technically should be in a env or smth but who cares ++ this is a get only endpoint
+const SCORECARD_API_KEY="BPGdOVwiRg9I45TLDD1bQfIxQjZW24K49ZEraSbS";
 
 class collegeController {
 
@@ -160,6 +162,29 @@ class collegeController {
     // createAssignment
 
     // deleteAssignment
+
+    // fetchFromScorecard
+    async fetchFromScorecard(namePrefix, desiredFields){
+        // DOCUMENTATION: https://github.com/RTICWDT/open-data-maker/blob/master/API.md
+        
+        // reformat spaces for url
+        const formattedPrefix=namePrefix.replace(/ /g, '%20');
+
+        let baseURL="https://api.data.gov/ed/collegescorecard/v1/schools.json?api_key="+SCORECARD_API_KEY;
+
+        if(formattedPrefix.length!=0){
+            baseURL+="&school.name="+formattedPrefix;
+        }
+
+        if(desiredFields.length!=0){
+            baseURL+="&fields="+desiredFields.join(",");
+        }
+
+        const response = await fetch(baseURL);
+        const data = await response.json();
+
+        return data;
+    }
 }
 
 module.exports = new collegeController();

--- a/backend/server.js
+++ b/backend/server.js
@@ -183,9 +183,9 @@ app.delete("/api/deleteCollege", (req, res) => {
 
 // fetchFromScorecard
 app.get("/api/fetchFromScorecard", (req, res) => {
-  const { namePrefix, desiredFields } = req.body;
+  const { namePrefix, desiredFields, findExact, page, perPage } = req.body;
   collegeController
-    .fetchFromScorecard(namePrefix, desiredFields)
+    .fetchFromScorecard(namePrefix, desiredFields, findExact, page, perPage)
     .then((data) =>
       res.status(200).json(data)
     )

--- a/backend/server.js
+++ b/backend/server.js
@@ -181,6 +181,19 @@ app.delete("/api/deleteCollege", (req, res) => {
 
 // deleteAssignment
 
+// fetchFromScorecard
+app.get("/api/fetchFromScorecard", (req, res) => {
+  const { namePrefix, desiredFields } = req.body;
+  collegeController
+    .fetchFromScorecard(namePrefix, desiredFields)
+    .then((data) =>
+      res.status(200).json(data)
+    )
+    .catch((error) => {
+      console.error(error);
+      return res.status(500).json({ error });
+    });
+});
 
 // *** USER API CALLS ***
 


### PR DESCRIPTION
What changed: Added functionality for fetching from remote db of collegescorecard
New dependencies: None(API key gen? i havent read it expires anywhere, we can make a place for users to enter their api key later if we want)
Testing: https://www.loom.com/share/38cce8eb7ba944d28671b56a97151644
Possible concerns: See loom i aint typing that shit out. also i think you have a way better idea of how this slots in. We aren't using it right away so im fine w this being merged then coming back to it 