### PR TITLE
Sprint 7: autofill college

### DIFF
--- a/backend/controller/college.controller.js
+++ b/backend/controller/college.controller.js
@@ -316,9 +316,9 @@ class collegeController {
                 collegeData[datum.columnName] = value;
             }
         });
-        
+        // this.createCollege(collegeData);
         //push to db
-        return this.createCollege(collegeData);
+        return collegeData;
     }
 
     // fetchFromScorecard

--- a/backend/controller/college.controller.js
+++ b/backend/controller/college.controller.js
@@ -289,17 +289,17 @@ class collegeController {
             { columnName: "min_act_math", objectPath: "latest.admissions.act_scores.25th_percentile.math" },
             { columnName: "max_act_math", objectPath: "latest.admissions.act_scores.75th_percentile.math" },
             { columnName: "faculty_student_ratio", objectPath: "latest.student.demographics.student_faculty_ratio" },
-            { columnName: "acceptance_rate", objectPath: "latest.admissions.admission_rate.overall" },
-            { columnName: "race_white", objectPath: "latest.student.demographics.race_ethnicity.white" },
-            { columnName: "race_black", objectPath: "latest.student.demographics.race_ethnicity.black" },
-            { columnName: "race_hispanic", objectPath: "latest.student.demographics.race_ethnicity.hispanic" },
-            { columnName: "race_asian", objectPath: "latest.student.demographics.race_ethnicity.asian" },
-            { columnName: "race_native_american", objectPath: "latest.student.demographics.race_ethnicity.aian" },
-            { columnName: "race_pacific_islander", objectPath: "latest.student.demographics.race_ethnicity.nhpi" },
-            { columnName: "race_two_or_more", objectPath: "latest.student.demographics.race_ethnicity.two_or_more" },
-            { columnName: "race_international", objectPath: "latest.student.demographics.race_ethnicity.non_resident_alien" },
-            { columnName: "race_other", objectPath: "latest.student.demographics.race_ethnicity.unknown" },
-            { columnName: "first_year_retention_rate", objectPath: "latest.student.retention_rate.four_year.full_time" },
+            { columnName: "acceptance_rate", objectPath: "latest.admissions.admission_rate.overall", multiplier: 100 },
+            { columnName: "race_white", objectPath: "latest.student.demographics.race_ethnicity.white", multiplier: 100 },
+            { columnName: "race_black", objectPath: "latest.student.demographics.race_ethnicity.black", multiplier: 100 },
+            { columnName: "race_hispanic", objectPath: "latest.student.demographics.race_ethnicity.hispanic", multiplier: 100 },
+            { columnName: "race_asian", objectPath: "latest.student.demographics.race_ethnicity.asian", multiplier: 100 },
+            { columnName: "race_native_american", objectPath: "latest.student.demographics.race_ethnicity.aian", multiplier: 100 },
+            { columnName: "race_pacific_islander", objectPath: "latest.student.demographics.race_ethnicity.nhpi", multiplier: 100 },
+            { columnName: "race_two_or_more", objectPath: "latest.student.demographics.race_ethnicity.two_or_more", multiplier: 100 },
+            { columnName: "race_international", objectPath: "latest.student.demographics.race_ethnicity.non_resident_alien", multiplier: 100 },
+            { columnName: "race_other", objectPath: "latest.student.demographics.race_ethnicity.unknown", multiplier: 100 },
+            { columnName: "first_year_retention_rate", objectPath: "latest.student.retention_rate.four_year.full_time", multiplier:100 },
             { columnName: "cost_tuition_in_state", objectPath: "latest.cost.tuition.in_state" },
             { columnName: "cost_tuition_out_of_state", objectPath: "latest.cost.tuition.out_of_state" },
             { columnName: "avg_total_cost_est", objectPath: "latest.cost.avg_net_price.overall" },
@@ -313,7 +313,10 @@ class collegeController {
         DATA_TO_FETCH.forEach((datum) => {
             const value = this.getValueByIndex(response, datum.objectPath);
             if(value){
-                collegeData[datum.columnName] = value;
+                collegeData[datum.columnName] = value.toString();
+                if(datum?.multiplier){
+                    collegeData[datum.columnName]=(Math.round(collegeData[datum.columnName]*datum.multiplier)).toString();
+                }
             }
         });
         // this.createCollege(collegeData);

--- a/backend/controller/college.controller.js
+++ b/backend/controller/college.controller.js
@@ -186,7 +186,7 @@ class collegeController {
     async createCollege(collegeData) {
         const insertKeys = Object.keys(collegeData);
         const insertValues = Object.values(collegeData);
-    
+        
         // create placeholder values ($1, $2, etc.) for each value to be inserted
         const placeholders = insertKeys
             .map((_, index) => `$${index + 1}`)
@@ -269,54 +269,53 @@ class collegeController {
 
         //MISSING FIELDS:
         /*
-            - Yo like im not a high schooler but i swear i had more shit on the act 
+            - Yo like im not a high schooler but i swear i had more shit on the act/sat 
             { name: "title_iv.transf_completed_4yr_by.2yrs", index: "latest.completion.title_iv.transf_completed_4yr_by.2yrs" },
             -             { name: "act_scores.25th_percentile.writing", index: "latest.admissions.act_scores.25th_percentile.writing" },
             { name: "act_scores.75th_percentile.writing", index: "latest.admissions.act_scores.75th_percentile.writing" }, IS THERE A WRITING SECTION IN ACT
         */
+       
         const DATA_TO_FETCH = [
-            { name: "location_city", index: "school.city" },
-            { name: "location_state", index: "school.state" },
-            { name: "min_sat_read_write", index: "latest.admissions.sat_scores.25th_percentile.critical_reading" },
-            { name: "max_sat_read_write", index: "latest.admissions.sat_scores.75th_percentile.critical_reading" },
-            { name: "min_sat_math", index: "latest.admissions.sat_scores.25th_percentile.math" },
-            { name: "max_sat_math", index: "latest.admissions.sat_scores.75th_percentile.math" },
-            { name: "min_act", index: "latest.admissions.act_scores.25th_percentile.cumulative" },
-            { name: "max_act", index: "latest.admissions.act_scores.75th_percentile.cumulative" },
-            { name: "min_act_english", index: "latest.admissions.act_scores.25th_percentile.english" },
-            { name: "max_act_english", index: "latest.admissions.act_scores.75th_percentile.english" },
-            { name: "min_act_math", index: "latest.admissions.act_scores.25th_percentile.math" },
-            { name: "max_act_math", index: "latest.admissions.act_scores.75th_percentile.math" },
-            { name: "faculty_student_ratio", index: "latest.student.demographics.student_faculty_ratio" },
-            { name: "acceptance_rate", index: "latest.admissions.admission_rate.overall" },
-            { name: "race_white", index: "latest.student.demographics.race_ethnicity.white" },
-            { name: "race_black", index: "latest.student.demographics.race_ethnicity.black" },
-            { name: "race_hispanic", index: "latest.student.demographics.race_ethnicity.hispanic" },
-            { name: "race_asian", index: "latest.student.demographics.race_ethnicity.asian" },
-            { name: "race_native_american", index: "latest.student.demographics.race_ethnicity.aian" },
-            { name: "race_pacific_islander", index: "latest.student.demographics.race_ethnicity.nhpi" },
-            { name: "race_two_or_more", index: "latest.student.demographics.race_ethnicity.two_or_more" },
-            { name: "race_international", index: "latest.student.demographics.race_ethnicity.non_resident_alien" },
-            { name: "race_other", index: "latest.student.demographics.race_ethnicity.unknown" },
-            { name: "first_year_retention_rate", index: "latest.student.retention_rate.four_year.full_time" },
-            { name: "cost_tuition_in_state", index: "latest.cost.tuition.in_state" },
-            { name: "cost_tuition_out_of_state", index: "latest.cost.tuition.out_of_state" },
-            { name: "avg_total_cost_est", index: "latest.cost.avg_net_price.overall" },
-            { name: "net_price_calc_web_addr", index: "latest.school.price_calculator_url" },
+            { columnName: "location_city", objectPath: "school.city" },
+            { columnName: "location_state", objectPath: "school.state" },
+            { columnName: "min_sat_read_write", objectPath: "latest.admissions.sat_scores.25th_percentile.critical_reading" },
+            { columnName: "max_sat_read_write", objectPath: "latest.admissions.sat_scores.75th_percentile.critical_reading" },
+            { columnName: "min_sat_math", objectPath: "latest.admissions.sat_scores.25th_percentile.math" },
+            { columnName: "max_sat_math", objectPath: "latest.admissions.sat_scores.75th_percentile.math" },
+            { columnName: "min_act", objectPath: "latest.admissions.act_scores.25th_percentile.cumulative" },
+            { columnName: "max_act", objectPath: "latest.admissions.act_scores.75th_percentile.cumulative" },
+            { columnName: "min_act_english", objectPath: "latest.admissions.act_scores.25th_percentile.english" },
+            { columnName: "max_act_english", objectPath: "latest.admissions.act_scores.75th_percentile.english" },
+            { columnName: "min_act_math", objectPath: "latest.admissions.act_scores.25th_percentile.math" },
+            { columnName: "max_act_math", objectPath: "latest.admissions.act_scores.75th_percentile.math" },
+            { columnName: "faculty_student_ratio", objectPath: "latest.student.demographics.student_faculty_ratio" },
+            { columnName: "acceptance_rate", objectPath: "latest.admissions.admission_rate.overall" },
+            { columnName: "race_white", objectPath: "latest.student.demographics.race_ethnicity.white" },
+            { columnName: "race_black", objectPath: "latest.student.demographics.race_ethnicity.black" },
+            { columnName: "race_hispanic", objectPath: "latest.student.demographics.race_ethnicity.hispanic" },
+            { columnName: "race_asian", objectPath: "latest.student.demographics.race_ethnicity.asian" },
+            { columnName: "race_native_american", objectPath: "latest.student.demographics.race_ethnicity.aian" },
+            { columnName: "race_pacific_islander", objectPath: "latest.student.demographics.race_ethnicity.nhpi" },
+            { columnName: "race_two_or_more", objectPath: "latest.student.demographics.race_ethnicity.two_or_more" },
+            { columnName: "race_international", objectPath: "latest.student.demographics.race_ethnicity.non_resident_alien" },
+            { columnName: "race_other", objectPath: "latest.student.demographics.race_ethnicity.unknown" },
+            { columnName: "first_year_retention_rate", objectPath: "latest.student.retention_rate.four_year.full_time" },
+            { columnName: "cost_tuition_in_state", objectPath: "latest.cost.tuition.in_state" },
+            { columnName: "cost_tuition_out_of_state", objectPath: "latest.cost.tuition.out_of_state" },
+            { columnName: "avg_total_cost_est", objectPath: "latest.cost.avg_net_price.overall" },
+            { columnName: "net_price_calc_web_addr", objectPath: "latest.school.price_calculator_url" },
         ];
 
         const response = await this.fetchFromScorecard(name, [], true, 0, 5);
         let collegeData = {};
         
-        DATA_TO_FETCH.forEach((datum) => {
-            const value = this.getValueByIndex(response, datum.index);
-            if(value){
-                collegeData[datum.name] = value;
-            }
-
-        });
         collegeData["college_name"] = name;
-
+        DATA_TO_FETCH.forEach((datum) => {
+            const value = this.getValueByIndex(response, datum.objectPath);
+            if(value){
+                collegeData[datum.columnName] = value;
+            }
+        });
         
         //push to db
         return this.createCollege(collegeData);
@@ -331,6 +330,7 @@ class collegeController {
      * @returns {object} If findExact, an object of the school info is returned. If not, a paged object of all autocomplete matches 
      */
     async fetchFromScorecard(namePrefix, desiredFields=[], findExact=false, page=0, perPage=20){
+        
         // DOCUMENTATION: https://github.com/RTICWDT/open-data-maker/blob/master/API.md
         // Technically should be in a env or smth but who cares ++ this is a get only endpoint  
         const SCORECARD_API_KEY="BPGdOVwiRg9I45TLDD1bQfIxQjZW24K49ZEraSbS";

--- a/backend/server.js
+++ b/backend/server.js
@@ -232,6 +232,28 @@ app.post("/api/collegesFiltered", (req, res) => {
     );
 });
 
+// autofillCollege
+app.post("/api/searchScorecard", (req, res) => {
+  const { collegeName } = req.body;
+  collegeController
+    .searchScorecard(collegeName)
+    .then((data)=>
+      res.status(200).json(data)
+    );
+});
+
+// autofillCollege
+app.post("/api/autofillCollege", (req, res) => {
+  const { collegeName } = req.body;
+  collegeController
+    .autofillCollege(collegeName)
+    .then((data)=>
+      res.status(200).json(data)
+    );
+});
+
+
+
 // *** USER API CALLS ***
 
 // allUsers

--- a/backend/server.js
+++ b/backend/server.js
@@ -252,8 +252,6 @@ app.post("/api/autofillCollege", (req, res) => {
     );
 });
 
-
-
 // *** USER API CALLS ***
 
 // allUsers

--- a/client/src/components/AutofillResultRow.tsx
+++ b/client/src/components/AutofillResultRow.tsx
@@ -3,12 +3,11 @@ import React from "react";
 type AutofillResultRowProps = {
     name: string;
     onSelect: () => void;
-    key: string;
 };
 
-const AutofillResultRow = ({ name, onSelect, key }: AutofillResultRowProps) => {
+const AutofillResultRow = ({ name, onSelect }: AutofillResultRowProps) => {
     return (
-        <div className="w-full border-b-1 border-black flex justify-between items-center px-6 py-4" key={key}>
+        <div className="w-full border-b-1 border-black flex justify-between items-center px-6 py-4" key={name}>
             <div className="font-circular-std">{name}</div>
             <div
                 className="cursor-pointer px-4 border border-black py-1 rounded-md bg-[#E6E6E6] text-xs ml-3"

--- a/client/src/components/AutofillResultRow.tsx
+++ b/client/src/components/AutofillResultRow.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+type AutofillResultRowProps = {
+    name: string;
+    onSelect: () => void;
+    key: string;
+};
+
+const AutofillResultRow = ({ name, onSelect, key }: AutofillResultRowProps) => {
+    return (
+        <div className="w-full border-b-1 border-black flex justify-between items-center px-6 py-4" key={key}>
+            <div className="font-circular-std">{name}</div>
+            <div
+                className="cursor-pointer px-4 border border-black py-1 rounded-md bg-[#E6E6E6] text-xs ml-3"
+                onClick={onSelect}
+            >
+                Select
+            </div>
+        </div>
+    );
+};
+
+export default AutofillResultRow;

--- a/client/src/components/CollegeFormFormSection.tsx
+++ b/client/src/components/CollegeFormFormSection.tsx
@@ -13,6 +13,7 @@ type CollegeFormFormSectionProps = {
   onNext: (data: any) => void;
   isLastTab: boolean;
   data?: any;
+  autofillData?: any;
 }
 
 
@@ -23,11 +24,19 @@ export const CollegeFormFormSection = ({
   onNext,
   isLastTab,
   data,
+  autofillData,
 }: CollegeFormFormSectionProps) => {
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
     defaultValues: data
   });
+
+  // somehow need to pass autofilled data here
+  useEffect(() => {
+    for (const property in autofillData) {
+      form.setValue(property, autofillData[property])
+    }
+  }, [form, autofillData])
 
   useEffect(() => {
     // no-op effect to trigger re-render on errors

--- a/client/src/layouts/AutofillCollege.tsx
+++ b/client/src/layouts/AutofillCollege.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from "react";
 import AutofillModal from "./AutofillModal";
 
-const AutofillCollege = () => {
+type AutofillCollegeProps={
+    stateAutofill: (arg1: boolean) => void;
+}
+
+const AutofillCollege = ({stateAutofill}: AutofillCollegeProps) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     return (
@@ -20,7 +24,7 @@ const AutofillCollege = () => {
                 </div>
             </div>
             <div className="z-50">
-                <AutofillModal isOpen={isModalOpen} setIsOpen={setIsModalOpen}/>
+                <AutofillModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} stateAutofill={stateAutofill}/>
             </div>
         </>
     );

--- a/client/src/layouts/AutofillCollege.tsx
+++ b/client/src/layouts/AutofillCollege.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from "react";
+import AutofillModal from "./AutofillModal";
+
+const AutofillCollege = () => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    return (
+        <>
+            <div className="flex w-full justify-between px-20 mt-4">
+                <div className="text-5xl font-bold font-grotesk">
+                    Add College
+                </div>
+                <div
+                    className="bg-[#1A1A1A] text-white flex justify-center items-center px-8 py-2 rounded-md cursor-pointer"
+                    onClick={() => {
+                        setIsModalOpen(true);
+                    }}
+                >
+                    Quick Fill
+                </div>
+            </div>
+            <div className="z-50">
+                <AutofillModal isOpen={isModalOpen} setIsOpen={setIsModalOpen}/>
+            </div>
+        </>
+    );
+};
+
+export default AutofillCollege;

--- a/client/src/layouts/AutofillModal.tsx
+++ b/client/src/layouts/AutofillModal.tsx
@@ -80,6 +80,10 @@ const AutofillModal = ({ isOpen, setIsOpen, stateAutofill }: AutofillModalProps)
             stateAutofill(data);
             if (data) {
                 toast("Success.");
+                setCollegeInput("");
+                setErrorMessage("");
+                setSearchResults([]);
+                setIsOpen(false);
             } else {
                 toast("Fail.");
             }

--- a/client/src/layouts/AutofillModal.tsx
+++ b/client/src/layouts/AutofillModal.tsx
@@ -1,0 +1,151 @@
+import React, { useState } from "react";
+import Modal from "react-modal";
+import X from "../components/X";
+import AutofillResultRow from "../components/AutofillResultRow";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+
+type AutofillModalProps = {
+    isOpen: boolean;
+    setIsOpen: (arg1: boolean) => void;
+};
+
+const customStyles = {
+    content: {
+        border: "2px solid lightgrey" as const,
+        width: "52%" as const,
+        margin: "auto" as const,
+    },
+    overlay: { zIndex: 1000 },
+};
+
+const AutofillModal = ({ isOpen, setIsOpen }: AutofillModalProps) => {
+    const [collegeInput, setCollegeInput] = useState("");
+    const [searchResults, setSearchResults] = useState([]);
+    const [showMessage, setShowMessage] = useState(true);
+    const [errorMessage, setErrorMessage] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+
+    const lookupCollege = async () => {
+        setShowMessage(false);
+
+        if (collegeInput.length === 0) {
+            setShowMessage(true);
+            setErrorMessage("Empty queries are not allowed.");
+            return;
+        }
+
+        const collegeLookupBody = JSON.stringify({
+            collegeName: collegeInput,
+        });
+        setIsLoading(true);
+        const response = await fetch("/api/searchScorecard", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: collegeLookupBody,
+        });
+        const data = await response.json();
+        setIsLoading(false);
+        if (data.length > 0) {
+            setSearchResults(data);
+        } else {
+            setSearchResults([]);
+            setShowMessage(true);
+            setErrorMessage(
+                ' No results found matching "' + collegeInput + '".'
+            );
+        }
+    };
+
+    const autofillCollege = (name: string) => {
+        return async () => {
+            const collegeLookupBody = JSON.stringify({
+                collegeName: name,
+            });
+            const response = await fetch("/api/autofillCollege", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: collegeLookupBody,
+            });
+            const data = await response.json();
+
+            if (data) {
+                toast("Success.");
+            } else {
+                toast("Fail.");
+            }
+            // setIsOpen(false);
+        };
+    };
+
+    return (
+        <Modal isOpen={isOpen} style={customStyles}>
+            <div className="px-16 py-12">
+                <div className="w-full flex justify-between">
+                    <div className="text-2xl font-bold font-grotesk">
+                        Quick Fill
+                    </div>
+                    <div
+                        onClick={() => {
+                            setIsOpen(false);
+                        }}
+                        className="cursor-pointer"
+                    >
+                        <X fill="black" />
+                    </div>
+                </div>
+                <div className="mt-4 flex w-full items-center">
+                    <input
+                        value={collegeInput}
+                        onChange={(e) => {
+                            setCollegeInput(e.target.value);
+                        }}
+                        className="border-2 border-black rounded h-9 w-full p-2"
+                        type="text"
+                    />
+                    <div
+                        className="bg-[#1A1A1A] text-white rounded-md px-4 py-2 ml-3 cursor-pointer"
+                        onClick={lookupCollege}
+                    >
+                        Search
+                    </div>
+                </div>
+                <div>
+                    {isLoading ? (
+                        <div className="text-4xl mt-16 text-center">Loading...</div>
+                    ) : (
+                        <div>
+                            {showMessage ? (
+                                <div className="mt-1 text-[#7B2525] font-circular-std">
+                                    {errorMessage}
+                                </div>
+                            ) : (
+                                <div className="mt-8">
+                                    <div className="h-px bg-black" />
+                                    {searchResults?.map((result) => {
+                                        return (
+                                            <AutofillResultRow
+                                                key={result}
+                                                name={result}
+                                                onSelect={autofillCollege(
+                                                    result
+                                                )}
+                                            />
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+            <ToastContainer hideProgressBar={true} />
+        </Modal>
+    );
+};
+
+export default AutofillModal;

--- a/client/src/layouts/AutofillModal.tsx
+++ b/client/src/layouts/AutofillModal.tsx
@@ -6,6 +6,7 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 type AutofillModalProps = {
+    stateAutofill: (arg1: boolean) => void;
     isOpen: boolean;
     setIsOpen: (arg1: boolean) => void;
 };
@@ -19,7 +20,7 @@ const customStyles = {
     overlay: { zIndex: 1000 },
 };
 
-const AutofillModal = ({ isOpen, setIsOpen }: AutofillModalProps) => {
+const AutofillModal = ({ isOpen, setIsOpen, stateAutofill }: AutofillModalProps) => {
     const [collegeInput, setCollegeInput] = useState("");
     const [searchResults, setSearchResults] = useState([]);
     const [showMessage, setShowMessage] = useState(true);
@@ -64,6 +65,7 @@ const AutofillModal = ({ isOpen, setIsOpen }: AutofillModalProps) => {
             const collegeLookupBody = JSON.stringify({
                 collegeName: name,
             });
+
             const response = await fetch("/api/autofillCollege", {
                 method: "POST",
                 headers: {
@@ -71,8 +73,11 @@ const AutofillModal = ({ isOpen, setIsOpen }: AutofillModalProps) => {
                 },
                 body: collegeLookupBody,
             });
-            const data = await response.json();
 
+            const data = await response.json();
+            console.log(data);
+            // pass data up
+            stateAutofill(data);
             if (data) {
                 toast("Success.");
             } else {
@@ -129,11 +134,8 @@ const AutofillModal = ({ isOpen, setIsOpen }: AutofillModalProps) => {
                                     {searchResults?.map((result) => {
                                         return (
                                             <AutofillResultRow
-                                                key={result}
                                                 name={result}
-                                                onSelect={autofillCollege(
-                                                    result
-                                                )}
+                                                onSelect={autofillCollege(result)}
                                             />
                                         );
                                     })}

--- a/client/src/layouts/CollegeFormPage.tsx
+++ b/client/src/layouts/CollegeFormPage.tsx
@@ -1,6 +1,5 @@
 import {useState} from "react";
 import {collegeFormSchemas} from "../util/college-form-schema";
-import {Navbar} from "./Navbar";
 import {CollegeProgressBar} from "../components/CollegeProgressBar";
 import {CollegeFormFormSection} from "../components/CollegeFormFormSection";
 import {collegeForm} from "../util/data/college-form";
@@ -9,10 +8,14 @@ import AutofillCollege from "./AutofillCollege";
 export default function CollegeFormPage({data, onSubmit}: { data?: any, onSubmit: (data: any) => void }) {
   const [formData, setFormData] = useState({})
   const [activeStep, setActiveStep] = useState(0);
+  const [autofillData, setAutofillData] = useState({})
 
   async function onNextButtonClick(data: any) {
     const updatedFormData = {...formData, ...data}
     setFormData(updatedFormData);
+
+    setAutofillData({'college_name': 'name', 'grad_rate_athletes': 50.0 })
+
 
     if (activeStep < collegeFormSchemas.length - 1) {
         setActiveStep(activeStep + 1);
@@ -22,8 +25,10 @@ export default function CollegeFormPage({data, onSubmit}: { data?: any, onSubmit
   const stateAutofill = async (collegeData : any) => {
     //fill in state object something {...formData,collegeData}
     // setFormData((prevData)=>{return {...prevData, ...collegeData}});
+
+    // possible solution?
+    // take existing formData and override all corresponding fields in autofillData
   }
-  console.log(formData);
   return <div className="h-screen w-screen flex flex-col items-center">
     <AutofillCollege stateAutofill={stateAutofill}/>
     <div className="max-w-6xl w-full">
@@ -37,6 +42,7 @@ export default function CollegeFormPage({data, onSubmit}: { data?: any, onSubmit
         onNext={onNextButtonClick}
         isLastTab={activeStep === collegeFormSchemas.length - 1}
         data={data}
+        autofillData={autofillData}
       />
     </div>
   </div>

--- a/client/src/layouts/CollegeFormPage.tsx
+++ b/client/src/layouts/CollegeFormPage.tsx
@@ -14,9 +14,6 @@ export default function CollegeFormPage({data, onSubmit}: { data?: any, onSubmit
     const updatedFormData = {...formData, ...data}
     setFormData(updatedFormData);
 
-    setAutofillData({'college_name': 'name', 'grad_rate_athletes': 50.0 })
-
-
     if (activeStep < collegeFormSchemas.length - 1) {
         setActiveStep(activeStep + 1);
     } else onSubmit(updatedFormData);
@@ -25,7 +22,7 @@ export default function CollegeFormPage({data, onSubmit}: { data?: any, onSubmit
   const stateAutofill = async (collegeData : any) => {
     //fill in state object something {...formData,collegeData}
     setAutofillData(collegeData);
-
+    console.log(collegeData);
     // possible solution?
     // take existing formData and override all corresponding fields in autofillData
   }

--- a/client/src/layouts/CollegeFormPage.tsx
+++ b/client/src/layouts/CollegeFormPage.tsx
@@ -24,7 +24,7 @@ export default function CollegeFormPage({data, onSubmit}: { data?: any, onSubmit
 
   const stateAutofill = async (collegeData : any) => {
     //fill in state object something {...formData,collegeData}
-    // setFormData((prevData)=>{return {...prevData, ...collegeData}});
+    setAutofillData(collegeData);
 
     // possible solution?
     // take existing formData and override all corresponding fields in autofillData

--- a/client/src/layouts/CollegeFormPage.tsx
+++ b/client/src/layouts/CollegeFormPage.tsx
@@ -15,12 +15,17 @@ export default function CollegeFormPage({data, onSubmit}: { data?: any, onSubmit
     setFormData(updatedFormData);
 
     if (activeStep < collegeFormSchemas.length - 1) {
-      setActiveStep(activeStep + 1)
+        setActiveStep(activeStep + 1);
     } else onSubmit(updatedFormData);
   }
 
+  const stateAutofill = async (collegeData : any) => {
+    //fill in state object something {...formData,collegeData}
+    // setFormData((prevData)=>{return {...prevData, ...collegeData}});
+  }
+  console.log(formData);
   return <div className="h-screen w-screen flex flex-col items-center">
-    <AutofillCollege/>
+    <AutofillCollege stateAutofill={stateAutofill}/>
     <div className="max-w-6xl w-full">
       <CollegeProgressBar activeStep={activeStep}/>
     </div>

--- a/client/src/layouts/CollegeFormPage.tsx
+++ b/client/src/layouts/CollegeFormPage.tsx
@@ -4,6 +4,7 @@ import {Navbar} from "./Navbar";
 import {CollegeProgressBar} from "../components/CollegeProgressBar";
 import {CollegeFormFormSection} from "../components/CollegeFormFormSection";
 import {collegeForm} from "../util/data/college-form";
+import AutofillCollege from "./AutofillCollege";
 
 export default function CollegeFormPage({data, onSubmit}: { data?: any, onSubmit: (data: any) => void }) {
   const [formData, setFormData] = useState({})
@@ -19,6 +20,7 @@ export default function CollegeFormPage({data, onSubmit}: { data?: any, onSubmit
   }
 
   return <div className="h-screen w-screen flex flex-col items-center">
+    <AutofillCollege/>
     <div className="max-w-6xl w-full">
       <CollegeProgressBar activeStep={activeStep}/>
     </div>


### PR DESCRIPTION
Notes/Assumptions:
- Debouncing isn't here, can do(current functionality is a search button)
- Some fields did not align(see comment)
- their api has some weirdness around fetching fields, so I fetched the whole object and parsed on the backend
- I equated min to 25th percentile and max to 75th for standardized testing
- code became very opinionated on how to do things so lmk if you see something different, I just didn't want to hardcode every object path
- ticket title mentions edit as well, I don't see a design for that(see where component for add is inserted)? 
- ticket shows top 3 results,, I did top 5,, college name search are pretty fuzzy so some other results show up often up to you(modal is somewhat bigger and this deviates). For example USC doesnt even show up in the top 3 results
- Is there an end state after they hit select?
- Anything to stop them from adding a college twice?
ok yea 