### PR TITLE
Sprint 11: Frontend Bugs

### DIFF
--- a/client/src/components/MentorDirectoryRow.tsx
+++ b/client/src/components/MentorDirectoryRow.tsx
@@ -4,14 +4,25 @@ import { Link, useParams, useNavigate } from "react-router-dom";
 
 type MentorDirectoryRowProps = {
     name: string;
-    sport: string;
-    major: string;
+    sport: string[];
+    major: string[];
     id: string;
+}
+
+function formatArray(array: string[]) {
+  const cell = array.filter(str => str !== "").join(", ");
+  if (cell.length > 20) {
+    return cell.substring(0, 17)+"...";
+} else {
+    return cell;
+}
 }
 
 const MentorDirectoryRow = ({ name, sport, major, id }: MentorDirectoryRowProps) => {
 
-    const navigate = useNavigate();
+  const navigate = useNavigate();
+  const sportCell = formatArray(sport);
+  const majorCell = formatArray(major);
 
   return (
     <tr
@@ -20,8 +31,8 @@ const MentorDirectoryRow = ({ name, sport, major, id }: MentorDirectoryRowProps)
       key={id}
     >
       <td className='pl-16'>{name}</td>
-      <td className='px-8'>{sport}</td>
-      <td className='pr-16'>{major}</td>
+      <td className='px-8'>{sportCell}</td>
+      <td className='pr-16'>{majorCell}</td>
     </tr>
   )
 }

--- a/client/src/components/StudentDirectoryRow.tsx
+++ b/client/src/components/StudentDirectoryRow.tsx
@@ -3,15 +3,25 @@ import { Link, useParams, useNavigate } from "react-router-dom";
 
 type StudentDirectoryRowProps = {
   name: string;
-  sport: string;
-  major: string;
+  sport: string[];
+  major: string[];
   id: string;
 };
+
+function formatArray(array: string[]) {
+  const cell = array.filter(str => str !== "").join(", ");
+  if (cell.length > 20) {
+    return cell.substring(0, 17)+"...";
+} else {
+    return cell;
+}
+}
 
 const StudentDirectoryRow = ({ name, sport, major, id }: StudentDirectoryRowProps) => {
 
   const navigate = useNavigate();
-
+  const sportCell = formatArray(sport);
+  const majorCell = formatArray(major);
   return (
     <tr
       className='h-12 border-b border-black cursor-pointer'
@@ -19,8 +29,8 @@ const StudentDirectoryRow = ({ name, sport, major, id }: StudentDirectoryRowProp
       key={id}
     >
       <td className='pl-16'>{name}</td>
-      <td className='px-8'>{sport}</td>
-      <td className='pr-16'>{major}</td>
+      <td className='px-8'>{sportCell}</td>
+      <td className='pr-16'>{majorCell}</td>
     </tr>
   )
 }

--- a/client/src/layouts/CollegeFilters.tsx
+++ b/client/src/layouts/CollegeFilters.tsx
@@ -16,7 +16,6 @@ export interface CollegeData {
     collegeHasDiversityResource?: boolean;
 }
 
-
 const CollegeFilters: React.FC<CollegeFiltersProps> = ({ onCollegeData }) => {
     // State for each form input
     const [collegeByName, setCollegeName] = useState("");
@@ -24,9 +23,12 @@ const CollegeFilters: React.FC<CollegeFiltersProps> = ({ onCollegeData }) => {
     const [collegeBySATRead, setSatEBRW] = useState("");
     const [collegeBySATMath, setSatMath] = useState("");
     const [collegeByACT, setActComposite] = useState("");
-    const [collegeHasStuAthAcademicRes, setStudentAthleteResources] = useState(false);
-    const [collegeHasAcademicResource, setStudentAcademicResources] = useState(false);
-    const [collegeHasDiversityResource, setDiversityResources] = useState(false);
+    const [collegeHasStuAthAcademicRes, setStudentAthleteResources] =
+        useState(false);
+    const [collegeHasAcademicResource, setStudentAcademicResources] =
+        useState(false);
+    const [collegeHasDiversityResource, setDiversityResources] =
+        useState(false);
 
     // Form submission handler
     const handleSubmit = (event: any) => {
@@ -45,13 +47,11 @@ const CollegeFilters: React.FC<CollegeFiltersProps> = ({ onCollegeData }) => {
         onCollegeData(formData); // Pass the form data to the parent component
     };
 
-
-
     // Checkbox custom icon
     const icon = (
         <svg xmlns="http://www.w3.org/2000/svg" className="h-9 w-9">
-            <rect className="h-9 w-9" rx="4" fill="#FFF"/>
-            <rect className="h-5 w-5" rx="4" x="7.5" y="7.5" fill="#577347"/>
+            <rect className="h-9 w-9" rx="4" fill="#FFF" />
+            <rect className="h-5 w-5" rx="4" x="7.5" y="7.5" fill="#577347" />
         </svg>
     );
 
@@ -63,9 +63,13 @@ const CollegeFilters: React.FC<CollegeFiltersProps> = ({ onCollegeData }) => {
             <div className="flex items-center place-content-between my-2">
                 <div>College Name</div>
                 <div className="w-40">
-                    <Input size="lg" value={collegeByName} onChange={(e) => setCollegeName(e.target.value)} crossOrigin={undefined} />
+                    <Input
+                        size="lg"
+                        value={collegeByName}
+                        onChange={(e) => setCollegeName(e.target.value)}
+                        crossOrigin={undefined}
+                    />
                 </div>
-
             </div>
 
             {/* Admission Statistics */}
@@ -73,44 +77,102 @@ const CollegeFilters: React.FC<CollegeFiltersProps> = ({ onCollegeData }) => {
             <div className="flex items-center place-content-between my-2">
                 <div>Average GPA</div>
                 <div className="w-40">
-                <Input size="lg" value={collegeByGPA} onChange={(e) => setAverageGPA(e.target.value)} crossOrigin={undefined} />
+                    <Input
+                        size="lg"
+                        value={collegeByGPA}
+                        onChange={(e) => setAverageGPA(e.target.value)}
+                        crossOrigin={undefined}
+                    />
                 </div>
             </div>
             <div className="flex items-center place-content-between my-2">
                 <div>SAT EBRW</div>
                 <div className="w-40">
-                <Input size="lg" value={collegeBySATRead} onChange={(e) => setSatEBRW(e.target.value)} crossOrigin={undefined}/>
+                    <Input
+                        size="lg"
+                        value={collegeBySATRead}
+                        onChange={(e) => setSatEBRW(e.target.value)}
+                        crossOrigin={undefined}
+                    />
                 </div>
             </div>
             <div className="flex items-center place-content-between my-2">
                 <div>SAT Math</div>
                 <div className="w-40">
-                <Input size="lg" value={collegeBySATMath} onChange={(e) => setSatMath(e.target.value)} crossOrigin={undefined} />
+                    <Input
+                        size="lg"
+                        value={collegeBySATMath}
+                        onChange={(e) => setSatMath(e.target.value)}
+                        crossOrigin={undefined}
+                    />
                 </div>
             </div>
             <div className="flex items-center place-content-between my-2">
                 <div>ACT Composite</div>
                 <div className="w-40">
-                <Input size="lg" value={collegeByACT} onChange={(e) => setActComposite(e.target.value)} crossOrigin={undefined} />
+                    <Input
+                        size="lg"
+                        value={collegeByACT}
+                        onChange={(e) => setActComposite(e.target.value)}
+                        crossOrigin={undefined}
+                    />
                 </div>
             </div>
 
             {/* Resources */}
             <div className="text-2xl font-bold">Resources</div>
             <div className="flex items-center space-x-2">
-                <Checkbox checked={collegeHasStuAthAcademicRes} onChange={(e) => setStudentAthleteResources(e.target.checked)} icon={icon} crossOrigin={undefined} />
+                <Checkbox
+                    checked={collegeHasStuAthAcademicRes}
+                    onChange={(e) =>
+                        setStudentAthleteResources(e.target.checked)
+                    }
+                    icon={icon}
+                    crossOrigin={undefined}
+                />
                 <div>Student Athlete Academic Resources</div>
             </div>
             <div className="flex items-center space-x-2">
-                <Checkbox checked={collegeHasAcademicResource} onChange={(e) => setStudentAcademicResources(e.target.checked)} icon={icon} crossOrigin={undefined} />
+                <Checkbox
+                    checked={collegeHasAcademicResource}
+                    onChange={(e) =>
+                        setStudentAcademicResources(e.target.checked)
+                    }
+                    icon={icon}
+                    crossOrigin={undefined}
+                />
                 <div>Student Academic Resources</div>
             </div>
             <div className="flex items-center space-x-2 pb-6">
-                <Checkbox checked={collegeHasDiversityResource} onChange={(e) => setDiversityResources(e.target.checked)} icon={icon} crossOrigin={undefined} />
+                <Checkbox
+                    checked={collegeHasDiversityResource}
+                    onChange={(e) => setDiversityResources(e.target.checked)}
+                    icon={icon}
+                    crossOrigin={undefined}
+                />
                 <div>Diversity Resources</div>
             </div>
-
-            <Button type="submit">Search</Button>
+            <div className="flex gap-4 w-full">
+                <Button className="w-full" type="submit">
+                    Search
+                </Button>
+                <Button
+                    variant="outlined"
+                    className="w-full"
+                    onClick={() => {
+                        setCollegeName("");
+                        setAverageGPA("");
+                        setSatEBRW("");
+                        setSatMath("");
+                        setActComposite("");
+                        setStudentAthleteResources(false);
+                        setStudentAcademicResources(false);
+                        setDiversityResources(false);
+                    }}
+                >
+                    Clear
+                </Button>
+            </div>
         </form>
     );
 };

--- a/client/src/layouts/CollegeSearchResults.tsx
+++ b/client/src/layouts/CollegeSearchResults.tsx
@@ -136,66 +136,66 @@ const CollegeSearchResults = (formData: any) => {
               })}
             </tbody>
           </table>
-            <div className="flex justify-center items-center gap-2 mt-16">
-                <button
-                    disabled={page === 1}
-                    className="relative h-8 max-h-[32px] w-8 max-w-[32px] select-none rounded-lg border border-gray-900 text-center align-middle font-sans text-xs font-medium uppercase text-gray-900 transition-all hover:opacity-75 active:opacity-[0.85] disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
-                    onClick={() => {
-                        setPage((p) => {
-                            return p - 1;
-                        });
-                    }}
-                >
-                    <span className="absolute transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            strokeWidth="2"
-                            stroke="currentColor"
-                            aria-hidden="true"
-                            className="w-4 h-4"
+          <div className="flex justify-start items-center gap-2 mt-16">
+                        <button
+                            disabled={page === 1 || totalPages === 0}
+                            className="relative h-8 max-h-[24px] w-8 max-w-[24px] select-none rounded-lg border border-gray-900 text-center align-middle font-sans text-xs font-medium uppercase text-gray-900 transition-all hover:opacity-75 active:opacity-[0.85] disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
+                            onClick={() => {
+                                setPage((p) => {
+                                    return p - 1;
+                                });
+                            }}
                         >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
-                            ></path>
-                        </svg>
-                    </span>
-                </button>
-                <span>
-                    Page {page} of {totalPages}
-                </span>
-                <button
-                    disabled={page === totalPages}
-                    className="relative h-8 max-h-[32px] w-8 max-w-[32px] select-none rounded-lg border border-gray-900 text-center align-middle font-sans text-xs font-medium uppercase text-gray-900 transition-all hover:opacity-75 active:opacity-[0.85] disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
-                    type="button"
-                    onClick={() => {
-                        setPage((p) => {
-                            return p + 1;
-                        });
-                    }}
-                >
-                    <span className="absolute transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            strokeWidth="2"
-                            stroke="currentColor"
-                            aria-hidden="true"
-                            className="w-4 h-4"
+                            <span className="absolute transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    strokeWidth="2"
+                                    stroke="currentColor"
+                                    aria-hidden="true"
+                                    className="w-4 h-4"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+                                    ></path>
+                                </svg>
+                            </span>
+                        </button>
+                        <span className="text-[#577347] text-[12px] font-circular-std">
+                            Page {page} of {totalPages}
+                        </span>
+                        <button
+                            disabled={page === totalPages || totalPages === 0}
+                            className="relative h-8 max-h-[24px] w-8 max-w-[24px] select-none rounded-lg border border-gray-900 text-center align-middle font-sans text-xs font-medium uppercase text-gray-900 transition-all hover:opacity-75 active:opacity-[0.85] disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
+                            type="button"
+                            onClick={() => {
+                                setPage((p) => {
+                                    return p + 1;
+                                });
+                            }}
                         >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
-                            ></path>
-                        </svg>
-                    </span>
-                </button>
-            </div>
+                            <span className="absolute transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    strokeWidth="2"
+                                    stroke="currentColor"
+                                    aria-hidden="true"
+                                    className="w-4 h-4"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
+                                    ></path>
+                                </svg>
+                            </span>
+                        </button>
+                    </div>
         </Card>
       );
 };

--- a/client/src/routes/MentorDatabase.tsx
+++ b/client/src/routes/MentorDatabase.tsx
@@ -89,8 +89,8 @@ const MentorDatabase = () => {
                                             " " +
                                             mentor?.mentor_lastname
                                         }
-                                        major={mentor?.mentor_major1}
-                                        sport={mentor?.mentor_sport1}
+                                        major={[mentor?.mentor_major1,mentor?.mentor_major2,mentor?.mentor_major3]}
+                                        sport={[mentor?.mentor_sport1, mentor?.mentor_sport2]}
                                         id={mentor?.mentor_id}
                                     />
                                 );

--- a/client/src/routes/MentorDatabase.tsx
+++ b/client/src/routes/MentorDatabase.tsx
@@ -201,7 +201,7 @@ const MentorDatabase = () => {
                             type="text"
                         />
                     </div>
-                    <div className="flex items-center justify-start mt-3 ">
+                    <div className="flex items-center justify-center mt-3 gap-4">
                         <div
                             onClick={() => {
                                 setFilterName(displayName);
@@ -209,7 +209,7 @@ const MentorDatabase = () => {
                                 setFilterMajor(displayMajor);
                                 setPage(1);
                             }}
-                            className="w-28 h-9 cursor-pointer bg-brand-gray-20 text-white font-medium px-8 py-[5px] mx-3 rounded"
+                            className="cursor-pointer bg-brand-gray-20 border-2 border-brand-gray-20 text-white font-medium px-8 py-[5px] mx-3 rounded"
                         >
                             Search
                         </div>
@@ -223,9 +223,9 @@ const MentorDatabase = () => {
                                 setFilterMajor("");
                                 setPage(1);
                             }}
-                            className="w-38 h-9 cursor-pointer bg-brand-gray-90 border-2 border-brand-gray-20 font-medium px-8 py-[5px] rounded"
+                            className="cursor-pointer bg-brand-gray-90 border-2 border-brand-gray-20 font-medium px-8 py-[5px] rounded"
                         >
-                            Clear Filters
+                            Clear
                         </div>
                     </div>
                 </div>

--- a/client/src/routes/StudentDatabase.tsx
+++ b/client/src/routes/StudentDatabase.tsx
@@ -82,8 +82,8 @@ const StudentDatabase = () => {
                                             " " +
                                             student?.user_lastname
                                         }
-                                        major={student?.user_potential_major}
-                                        sport={student?.user_sport1}
+                                        major={[student?.user_potential_major,student?.user_alt_major1,student?.user_alt_major2]}
+                                        sport={[student?.user_sport1, student?.user_sport2]}
                                         id={student?.user_id}
                                     />
                                 );

--- a/client/src/routes/StudentDatabase.tsx
+++ b/client/src/routes/StudentDatabase.tsx
@@ -87,7 +87,7 @@ const StudentDatabase = () => {
                                         id={student?.user_id}
                                     />
                                 );
-                            })}                          
+                            })}
                         </tbody>
                     </table>
                     <div className="flex justify-start items-center gap-2 mt-16">
@@ -194,7 +194,7 @@ const StudentDatabase = () => {
                             type="text"
                         />
                     </div>
-                    <div className="flex items-center justify-start mt-3 ">
+                    <div className="flex items-center justify-center mt-3 gap-4">
                         {/* Auth Wrapper */}
                         <div
                             onClick={() => {
@@ -203,9 +203,19 @@ const StudentDatabase = () => {
                                 setFilterMajor(displayMajor);
                                 setPage(1);
                             }}
-                            className="w-28 h-9 cursor-pointer bg-brand-gray-20 text-white font-medium px-8 py-[5px] rounded"
+                            className="cursor-pointer bg-brand-gray-20 border-2 border-brand-gray-20 text-white font-medium px-8 py-[5px] mx-3 rounded"
                         >
                             Search
+                        </div>
+                        <div
+                            onClick={() => {
+                                setDisplayName("");
+                                setDisplayMajor("");
+                                setDisplaySport("");
+                            }}
+                            className="cursor-pointer bg-brand-gray-90 border-2 border-brand-gray-20 font-medium px-8 py-[5px] rounded"
+                        >
+                            Clear
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
I'm not sure what the last point meant, but we can get this out if its in a rush:

Right now the student/mentor database row results only show the first major/sport but the filters search by all 3. Make it display all 3 majors/sports instead separated by commas. If the collective string is longer than 20 chars, cut it off at 20 chars ad add a “…” at the end

the table rn shows both major and sport, im confused what more information could be rendered? 