### PR TITLE
Bug - Mentor Profile Invalid Ids

### DIFF
--- a/client/src/routes/MentorProfile.tsx
+++ b/client/src/routes/MentorProfile.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import MentorProfile from "../layouts/MentorProfile";
 import { useParams } from "react-router-dom";
+import NotFoundPage from "./NotFoundPage";
 
 export interface mentorData {
     mentor_id: number;
@@ -30,6 +31,7 @@ export interface mentorData {
 
 const MentorProfileViewRoute = () => {
     const [mentorData, setMentorData] = useState({} as mentorData);
+    const [validID, setValidID] = useState(true);
     const {id} = useParams();
 
     useEffect(() => {
@@ -48,8 +50,12 @@ const MentorProfileViewRoute = () => {
             });
 
             const data = await response.json();
-            console.log("data:", data[0]);
             setMentorData(data[0]);
+
+            if (Object.keys(data).length === 0)
+                setValidID(false);
+            else
+                setValidID(true);
         } catch (error) {
             console.error("Error fetching mentor data:", error);
         }
@@ -59,9 +65,13 @@ const MentorProfileViewRoute = () => {
 
     return (
         <div>
-            <MentorProfile
-                mentorData={mentorData}
-            />
+            {validID ? (
+                <MentorProfile
+                    mentorData={mentorData}
+                />
+            ) : (
+                <NotFoundPage/>
+            )}
         </div>
     );
 };

--- a/client/src/routes/StudentProfile.tsx
+++ b/client/src/routes/StudentProfile.tsx
@@ -81,7 +81,7 @@ const StudentProfileRoute = () => {
   const { id } = useParams();
 
   const [studentData, setStudentData] = useState<studentData>({} as studentData);
-  const [validID, setValidID] = useState(false);
+  const [validID, setValidID] = useState(true);
   const [collegeAssignments, setCollegeAssignments] = useState<collegeAssignments[]>([]);
   const [peerData, setPeerData] = useState<peerData>({} as peerData);
   const [cookies] = useCookies(['user_id', 'user_status', 'user_name']);
@@ -152,7 +152,6 @@ const StudentProfileRoute = () => {
         const data = await response.json();
         setStudentData(data[0]);
         setPeerData(data[0]);
-        console.log("studentData:", studentData);
         
         if (Object.keys(data).length === 0)
           setValidID(false);
@@ -217,8 +216,6 @@ const StudentProfileRoute = () => {
       console.error('Error creating assignment:', error);
     }
   };
-
-  console.log("ValidID " + validID);
 
   return (
     


### PR DESCRIPTION
Show 404 page for nonexistent mentors.
Change validID default to true so 404 page doesn't glitch when a valid mentor/student profile is routed to.